### PR TITLE
Try to keep password history ordered properly to decrease surprises

### DIFF
--- a/keg_bouncer/model/mixins.py
+++ b/keg_bouncer/model/mixins.py
@@ -175,7 +175,13 @@ def make_password_mixin(history_entity_mixin=object, crypt_context=None):
                 password=crypt_context.encrypt(text_type(password)),
                 **kwargs
             )
+
+            # Assume the new password is more recent than the others and insert it at the head.
             self.password_history.insert(0, password_entry)
+
+            # If we have timestamps for all history, we can sort them.
+            if not any(x.created_at is None for x in self.password_history):
+                self.password_history.sort(key=lambda x: x.created_at, reverse=True)
 
     return PasswordMixin
 


### PR DESCRIPTION
Especially in testing it's possible to add passwords out of order so this change makes such tests easier to get right. Also in production if a timestamp is ever given explicitly it becomes very important to make sure the passwords are properly ordered.
