### PR TITLE
Update apt package list before attempting to install libpython3.4 in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ dependencies:
     # Python binaries of the same major version onto the path at the same time
     - pip install tox tox-pyenv
     - pyenv local 2.7.6 3.4.3 3.5.0 pypy-2.5.0
+    - sudo apt-get update --fix-missing
     - sudo apt-get install -y -qq libpython3.4
 
     # Install the deadsnakes ppa repo so we can install libpython3.5


### PR DESCRIPTION
This fixes the error occurring while installing python 3.4 as seen here: https://circleci.com/gh/level12/keg-bouncer/78